### PR TITLE
Update requirements.in

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -169,6 +169,7 @@ python-multipart
 psycopg2-binary
 alembic
 rich
+pydantic<2
 ```
 
 A partir deste arquivo vamos gerar um `requirements.txt` com os locks das

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ python-multipart
 psycopg2-binary
 alembic
 rich
+pydantic<2


### PR DESCRIPTION
A v2 do Pydantic alterou a especificação/api para customização de campo para ser usado no SQLModel, impedindo que o campo de senha seja salvo em hash no banco de dados.